### PR TITLE
fix(middleware): Always send `Content-Type` headers.

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,6 +120,7 @@ module.exports = function(options) {
             }
 
             if (!cacheMiss) {
+                res.append('Content-Type', 'application/javascript');
                 res.append('X-Babel-Cache-Hit', true);
                 if (isMemoryCache) {
                     log('Serving (cached): %s', src);
@@ -169,6 +170,7 @@ module.exports = function(options) {
             });
         }
         log('Serving (uncached): %s', src);
+        res.append('Content-Type', 'application/javascript');
         res.write(code);
         res.end();
     };

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -17,6 +17,7 @@ function baseSuite() {
         it('hits the proxy', function(done) {
             request(this.app)
                 .get('/counter.js')
+                .expect('Content-Type', 'application/javascript')
                 .expect('X-Babel-Cache', 'true')
                 .expect(200, done);
         });
@@ -24,6 +25,7 @@ function baseSuite() {
         it("doesn't get a cache hit", function(done) {
             request(this.app)
                 .get('/counter.js')
+                .expect('Content-Type', 'application/javascript')
                 .expect('X-Babel-Cache-Hit', 'false')
                 .expect(200, done);
         });
@@ -33,6 +35,7 @@ function baseSuite() {
 
             request(this.app)
                 .get('/counter.js')
+                .expect('Content-Type', 'application/javascript')
                 .expect('X-Babel-Cache', 'true')
                 .expect(200)
                 .expect(expectedCode, done);
@@ -47,6 +50,7 @@ function baseSuite() {
         it('should get a cache hit', function(done) {
             request(this.app)
                 .get('/counter.js')
+                .expect('Content-Type', 'application/javascript')
                 .expect('X-Babel-Cache-Hit', 'true')
                 .expect(200, done);
         });
@@ -56,6 +60,7 @@ function baseSuite() {
 
             request(this.app)
                 .get('/counter.js')
+                .expect('Content-Type', 'application/javascript')
                 .expect('X-Babel-Cache', 'true')
                 .expect('X-Babel-Cache-Hit', 'true')
                 .expect(200)
@@ -106,6 +111,7 @@ function baseSuite() {
         it('does not return a cached response', function(done) {
             request(this.app)
                 .get(this.url)
+                .expect('Content-Type', 'application/javascript')
                 .expect('X-Babel-Cache-Hit', 'false')
                 .expect(200, done);
         });
@@ -208,6 +214,7 @@ describe('middleware', function() {
             it('uses previously cached assets', function(done) {
                 request(this.app)
                     .get('/counter.js')
+                    .expect('Content-Type', 'application/javascript')
                     .expect('X-Babel-Cache-Hit', 'true')
                     .expect(200, done);
             });
@@ -222,6 +229,7 @@ describe('middleware', function() {
                 it('loads an uncached version again', function(done) {
                     request(this.app)
                         .get('/counter.js')
+                        .expect('Content-Type', 'application/javascript')
                         .expect('X-Babel-Cache-Hit', 'false')
                         .expect(200, done);
                 });
@@ -262,6 +270,7 @@ describe('middleware', function() {
 
             request(this.app)
                 .get('/counter-syntax-error.js')
+                .expect('Content-Type', 'application/javascript')
                 .expect('X-Babel-Cache', 'false')
                 .expect(200)
                 .expect(expectedCode, done);


### PR DESCRIPTION
fixes #6
